### PR TITLE
Remove unnecessary DOCTYPE tags from heatmaps

### DIFF
--- a/_includes/geo_heatmap_actual_numbers.html
+++ b/_includes/geo_heatmap_actual_numbers.html
@@ -1,8 +1,3 @@
-
-
-
-
-<!DOCTYPE html>
 <html lang="en">
   
   <head>

--- a/_includes/geo_heatmap_relative_numbers.html
+++ b/_includes/geo_heatmap_relative_numbers.html
@@ -1,8 +1,3 @@
-
-
-
-
-<!DOCTYPE html>
 <html lang="en">
   
   <head>


### PR DESCRIPTION
These are currently visible on the page